### PR TITLE
go-wrapper has been deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ ddg
 
 # Config files
 ddg.env
+ddg.yaml
 
 # Glide
 vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM golang:1.10-alpine as build-env
 
 # Change when glide updates
 ENV GLIDE_VER v0.13.1
@@ -25,8 +25,11 @@ RUN glide --no-color install
 # Copy over source
 COPY . .
 
-# Install, build and remove deps
-RUN go-wrapper install github.com/aurieh/ddg-ng && \
-	apk del -q .build-deps
+# Build and install the binary.
+RUN go install github.com/aurieh/ddg-ng
 
-ENTRYPOINT ["go-wrapper", "run"]
+# Make the minimal runtime container from the binary.
+FROM golang:1.10-alpine
+
+COPY --from=build-env /go/bin/ddg-ng /go/bin/
+ENTRYPOINT ["ddg-ng"]

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ A [DuckDuckGo](https://duckduckgo.com) bot for [Discord](https://discordapp.com)
 # Building with Docker
 `git clone https://github.com/aurieh/ddg-ng` then `docker build -t aurieh/ddg-ng .`.
 
+To run, you can use several ways to provide the [required token](https://github.com/reactiflux/discord-irc/wiki/Creating-a-discord-bot-&-getting-a-token).
+```sh
+# Using a command line argument
+docker run aurieh/ddg-ng --token=asdf1234
+
+# Using an ENV var
+docker run -e token=asdf1234 aurieh/ddg-ng
+
+# Using a yaml settings file
+echo 'token: asdf1234' > ddg.yaml
+docker run -v $(pwd)/ddg.yaml:/etc/ddg/ddg.yaml aurieh/ddg-ng
+```
+
 # Building manually
 `git clone https://github.com/aurieh/ddg-ng`, `glide install` and `go build`.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,4 +3,6 @@ version: '3'
 services:
    ddg:
       build: .
-      env_file: ddg.env
+      command: --debug
+      volumes:
+        - ./ddg.yaml:/etc/ddg/ddg.yaml


### PR DESCRIPTION
In 1.10 of the golang docker image `go-wrapper` is no longer available.
This is a clean approach that preserves the resulting binary only.